### PR TITLE
Actually skip goals when configured to do so

### DIFF
--- a/src/main/java/com/cosium/code/format/AbstractModuleMavenGitCodeFormatMojo.java
+++ b/src/main/java/com/cosium/code/format/AbstractModuleMavenGitCodeFormatMojo.java
@@ -59,6 +59,7 @@ public abstract class AbstractModuleMavenGitCodeFormatMojo extends AbstractMaven
       if (log.isInfoEnabled()) {
         log.info("skipped");
       }
+      return;
     }
     if (!isEnabled()) {
       return;

--- a/src/main/java/com/cosium/code/format/InstallHooksMojo.java
+++ b/src/main/java/com/cosium/code/format/InstallHooksMojo.java
@@ -80,6 +80,7 @@ public class InstallHooksMojo extends AbstractMavenGitCodeFormatMojo {
       if (log.isInfoEnabled()) {
         log.info("skipped");
       }
+      return;
     }
 
     try {


### PR DESCRIPTION
Git hook installation and code validation are not being skipped when configured to do so as per the README. Example reproduction:
1. Create new empty Maven project
1. Add v2.4 of the plugin as specified in the README
1. Run `mvn test -Dgcf.skip=true` (or otherwise configure such parameter from the POM)
1. Output will contain:
    ```
    [INFO] --- git-code-format-maven-plugin:2.4:install-hooks (install-formatter-hook) @ test ---
    [INFO] skipped
    [INFO] Installing git hooks
    [INFO] Installed git hooks
    ```
    and `ls .git/hooks` will show the hook is indeed installed.

This PR simply adds a `return` statement when `skip` is enabled to actually skip.