### PR TITLE
feat: add `useGlobalMavenExecutable` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,21 @@ set -e
 
 On `pre-commit` git phase, the hook triggers the `git-code-format:on-pre-commit` which formats the code of the modified java files using `google-java-format`.
 
+### Configuring Maven Executable Path
+By default, the plugin will generate the following maven path
+
+```shell
+"${env.M2_HOME}/bin/mvn"
+```
+
+If you want to use the global `mvn` variable, you can configure it using the `useGlobalMavenExecutable` property.
+
+```xml
+      <configuration>
+        <useGlobalMavenExecutable>true</useGlobalMavenExecutable>
+      </configuration>
+```
+
 ### Advanced pre-commit pipeline hook
 If you wish to modify the output of the pre-commit hook, you can set the `preCommitHookPipeline` configuration.
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.cosium.code</groupId>
   <artifactId>git-code-format-maven-plugin</artifactId>
-  <version>2.8</version>
+  <version>2.7</version>
   <packaging>maven-plugin</packaging>
 
   <name>Git Code Format Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.cosium.code</groupId>
   <artifactId>git-code-format-maven-plugin</artifactId>
-  <version>2.7</version>
+  <version>2.8</version>
   <packaging>maven-plugin</packaging>
 
   <name>Git Code Format Maven Plugin</name>

--- a/src/main/java/com/cosium/code/format/InstallHooksMojo.java
+++ b/src/main/java/com/cosium/code/format/InstallHooksMojo.java
@@ -2,7 +2,6 @@ package com.cosium.code.format;
 
 import static java.util.Optional.ofNullable;
 
-
 import com.cosium.code.format.executable.Executable;
 import com.cosium.code.format.executable.ExecutableManager;
 import com.cosium.code.format.maven.MavenEnvironment;
@@ -144,9 +143,7 @@ public class InstallHooksMojo extends AbstractMavenGitCodeFormatMojo {
 
   private String mavenCliArguments() {
     Stream<String> propagatedProperties =
-        ofNullable(propertiesToPropagate)
-            .map(Arrays::asList)
-            .orElse(Collections.emptyList())
+        ofNullable(propertiesToPropagate).map(Arrays::asList).orElse(Collections.emptyList())
             .stream()
             .filter(prop -> System.getProperty(prop) != null)
             .map(prop -> "-D" + prop + "=" + System.getProperty(prop));


### PR DESCRIPTION
This PR Addresses #71 by adding a new configuration option to allow users to override usage of `M2_HOME` to directly use the global `mvn` variable instead.

This should allow users to allow use maven from IDE's where `M2_HOME` is sometime forcefully set by the tooling, eg. when using maven from IntelliJ IDEA