### PR TITLE
Optionally allow overwriting of the hooks file name

### DIFF
--- a/src/main/java/com/cosium/code/format/AbstractModuleMavenGitCodeFormatMojo.java
+++ b/src/main/java/com/cosium/code/format/AbstractModuleMavenGitCodeFormatMojo.java
@@ -44,7 +44,8 @@ public abstract class AbstractModuleMavenGitCodeFormatMojo extends AbstractMaven
     if ((!includedModules.isEmpty() || !excludedModules.isEmpty()) && isExecutionRoot()) {
       getLog()
           .info(
-              "Explicit included or excluded modules defined and the current module the execution root. Goal disabled.");
+              "Explicit included or excluded modules defined and the current module the execution"
+                  + " root. Goal disabled.");
       return false;
     }
 

--- a/src/main/java/com/cosium/code/format/FormatCodeMojo.java
+++ b/src/main/java/com/cosium/code/format/FormatCodeMojo.java
@@ -2,15 +2,14 @@ package com.cosium.code.format;
 
 import com.cosium.code.format.formatter.CodeFormatter;
 import com.cosium.code.format.formatter.LineRanges;
-import org.apache.commons.io.IOUtils;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
-import org.apache.maven.plugins.annotations.Mojo;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.apache.commons.io.IOUtils;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
 
 /**
  * Created on 07/11/17.

--- a/src/main/java/com/cosium/code/format/TemporaryFile.java
+++ b/src/main/java/com/cosium/code/format/TemporaryFile.java
@@ -1,13 +1,12 @@
 package com.cosium.code.format;
 
-import org.apache.maven.plugin.logging.Log;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.apache.maven.plugin.logging.Log;
 
 /** @author Réda Housni Alaoui */
 public class TemporaryFile implements Closeable {

--- a/src/main/java/com/cosium/code/format/executable/DefaultCommandRunner.java
+++ b/src/main/java/com/cosium/code/format/executable/DefaultCommandRunner.java
@@ -1,14 +1,13 @@
 package com.cosium.code.format.executable;
 
 import com.cosium.code.format.MavenGitCodeFormatException;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.maven.plugin.logging.Log;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.function.Supplier;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.plugin.logging.Log;
 
 /** @author Réda Housni Alaoui */
 public class DefaultCommandRunner implements CommandRunner {

--- a/src/main/java/com/cosium/code/format/git/AutoCRLFObjectReader.java
+++ b/src/main/java/com/cosium/code/format/git/AutoCRLFObjectReader.java
@@ -1,5 +1,10 @@
 package com.cosium.code.format.git;
 
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Set;
 import org.eclipse.jgit.errors.IncorrectObjectTypeException;
 import org.eclipse.jgit.errors.MissingObjectException;
 import org.eclipse.jgit.lib.AbbreviatedObjectId;
@@ -8,12 +13,6 @@ import org.eclipse.jgit.lib.CoreConfig.EolStreamType;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectLoader;
 import org.eclipse.jgit.lib.ObjectReader;
-
-import java.io.IOException;
-import java.util.Collection;
-import java.util.Set;
-
-import static java.util.Objects.requireNonNull;
 
 /** @author Réda Housni Alaoui */
 public class AutoCRLFObjectReader extends ObjectReader {

--- a/src/main/java/com/cosium/code/format/git/AutoCRLFObjectStream.java
+++ b/src/main/java/com/cosium/code/format/git/AutoCRLFObjectStream.java
@@ -1,13 +1,12 @@
 package com.cosium.code.format.git;
 
-import org.eclipse.jgit.lib.CoreConfig.EolStreamType;
-import org.eclipse.jgit.lib.ObjectStream;
-import org.eclipse.jgit.util.io.EolStreamTypeUtil;
+import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
 import java.io.InputStream;
-
-import static java.util.Objects.requireNonNull;
+import org.eclipse.jgit.lib.CoreConfig.EolStreamType;
+import org.eclipse.jgit.lib.ObjectStream;
+import org.eclipse.jgit.util.io.EolStreamTypeUtil;
 
 /** @author Réda Housni Alaoui */
 public class AutoCRLFObjectStream extends ObjectStream {

--- a/src/main/java/com/cosium/code/format/git/AutoCRLFRepository.java
+++ b/src/main/java/com/cosium/code/format/git/AutoCRLFRepository.java
@@ -1,13 +1,12 @@
 package com.cosium.code.format.git;
 
-import org.eclipse.jgit.internal.storage.file.FileRepository;
-import org.eclipse.jgit.lib.CoreConfig.EolStreamType;
-import org.eclipse.jgit.lib.ObjectReader;
+import static java.util.Objects.requireNonNull;
 
 import java.io.File;
 import java.io.IOException;
-
-import static java.util.Objects.requireNonNull;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
+import org.eclipse.jgit.lib.CoreConfig.EolStreamType;
+import org.eclipse.jgit.lib.ObjectReader;
 
 /** @author Réda Housni Alaoui */
 public class AutoCRLFRepository extends FileRepository {

--- a/src/main/java/com/cosium/code/format/git/GitIndexEntry.java
+++ b/src/main/java/com/cosium/code/format/git/GitIndexEntry.java
@@ -144,8 +144,12 @@ class GitIndexEntry {
       }
 
       try {
-        return git.diff().setPathFilter(PathFilter.create(dirCacheEntry.getPathString()))
-            .setCached(true).call().stream()
+        return git
+            .diff()
+            .setPathFilter(PathFilter.create(dirCacheEntry.getPathString()))
+            .setCached(true)
+            .call()
+            .stream()
             .map(this::computeLineRanges)
             .reduce(LineRanges::concat)
             .orElse(LineRanges.all());

--- a/src/main/java/com/cosium/code/format/git/GitStagedFiles.java
+++ b/src/main/java/com/cosium/code/format/git/GitStagedFiles.java
@@ -1,8 +1,19 @@
 package com.cosium.code.format.git;
 
+import static java.util.Objects.requireNonNull;
+
 import com.cosium.code.format.MavenGitCodeFormatException;
 import com.cosium.code.format.TemporaryFile;
 import com.cosium.code.format.formatter.CodeFormatters;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.maven.plugin.logging.Log;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.Status;
@@ -15,18 +26,6 @@ import org.eclipse.jgit.lib.CoreConfig.EolStreamType;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.treewalk.AbstractTreeIterator;
 import org.eclipse.jgit.treewalk.WorkingTreeOptions;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.file.Path;
-import java.util.Collections;
-import java.util.Set;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static java.util.Objects.requireNonNull;
 
 /** @author Réda Housni Alaoui */
 public class GitStagedFiles {

--- a/src/main/java/com/cosium/code/format/git/Index.java
+++ b/src/main/java/com/cosium/code/format/git/Index.java
@@ -1,12 +1,11 @@
 package com.cosium.code.format.git;
 
+import java.io.IOException;
 import org.eclipse.jgit.dircache.DirCache;
 import org.eclipse.jgit.dircache.DirCacheEditor;
 import org.eclipse.jgit.dircache.DirCacheIterator;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.treewalk.AbstractTreeIterator;
-
-import java.io.IOException;
 
 /** @author Réda Housni Alaoui */
 public class Index implements AutoCloseable {


### PR DESCRIPTION
In one of my teams my colleagues discovered a problem:
If you run a multi-module project, the script initializes a hook for each module which you might have executed.
E.g. if you ran the project on root level, but at a later time only a sub module, to save some time compiling and testing...

This means the check will be executed for each module which had a maven run beforehand. 
In order to circumvent that, a configuration option where you'd be able to override the generated script's name would be beneficial.

I provided a PR adding a config option which will be taken in favour of the artifactId if it is set.

Additionally I formatted the code with the google formatter ;)