### PR TITLE
Fix java problems

### DIFF
--- a/src/main/java/com/cosium/code/format/AbstractMavenGitCodeFormatMojo.java
+++ b/src/main/java/com/cosium/code/format/AbstractMavenGitCodeFormatMojo.java
@@ -42,7 +42,7 @@ public abstract class AbstractMavenGitCodeFormatMojo extends AbstractMojo {
   @Parameter(defaultValue = "${project.build.sourceEncoding}")
   private String sourceEncoding;
 
-  public AbstractMavenGitCodeFormatMojo() {
+  protected AbstractMavenGitCodeFormatMojo() {
     codeFormatters =
         () ->
             Collections.singletonList(

--- a/src/main/java/com/cosium/code/format/executable/CommandRunException.java
+++ b/src/main/java/com/cosium/code/format/executable/CommandRunException.java
@@ -14,7 +14,7 @@ public class CommandRunException extends RuntimeException {
   public CommandRunException(int exitCode, String output, String... command) {
     super(
         String.format(
-            "'%s' failed with code %s: \n\n %s",
+            "'%s' failed with code %s: %n%n %s",
             StringUtils.join(command, StringUtils.SPACE), exitCode, output));
     this.exitCode = exitCode;
   }

--- a/src/main/java/com/cosium/code/format/formatter/GoogleJavaFormatter.java
+++ b/src/main/java/com/cosium/code/format/formatter/GoogleJavaFormatter.java
@@ -87,7 +87,8 @@ public class GoogleJavaFormatter implements CodeFormatter {
       formattedContent = RemoveUnusedImports.removeUnusedImports(formattedContent);
     }
     if (!options.isSkipSortingImports()) {
-      formattedContent = ImportOrderer.reorderImports(formattedContent);
+      formattedContent =
+          ImportOrderer.reorderImports(formattedContent, options.javaFormatterOptions().style());
     }
     return formattedContent;
   }

--- a/src/main/java/com/cosium/code/format/git/AutoCRLFObjectLoader.java
+++ b/src/main/java/com/cosium/code/format/git/AutoCRLFObjectLoader.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.CountingInputStream;
 import org.eclipse.jgit.errors.LargeObjectException;
@@ -45,7 +46,7 @@ public class AutoCRLFObjectLoader extends ObjectLoader {
       }
       cachedSize = countingInputStream.getByteCount();
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
     return cachedSize;
   }
@@ -71,7 +72,7 @@ public class AutoCRLFObjectLoader extends ObjectLoader {
       return IOUtils.toByteArray(
           EolStreamTypeUtil.wrapInputStream(new ByteArrayInputStream(bytes), eolStreamType));
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
   }
 

--- a/src/test/java/com/cosium/code/format/AbstractTest.java
+++ b/src/test/java/com/cosium/code/format/AbstractTest.java
@@ -119,7 +119,7 @@ public abstract class AbstractTest {
   protected String sha1(String sourceName) {
     try (InputStream inputStream =
         Files.newInputStream(resolveRelativelyToProjectRoot(sourceName))) {
-      return DigestUtils.shaHex(inputStream);
+      return DigestUtils.sha1Hex(inputStream);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
This branch contains quick fixes for some Java problems which were reported by my IDE (Visual Studio Code with SonarLint extension).

FYI: I didn't make any changes for the following warnings in `src/main/java/com/cosium/code/format/AbstractModuleMavenGitCodeFormatMojo.java`:

> Rename "excludedModules" which hides the field declared at line 25.
> Rename "includedModules" which hides the field declared at line 22.

> Local variables should not shadow class fields.

I thought about renaming these local variables to "nullSafeExcludedModules" and "nullSafeIncludedModules" respectively, because the reason to introduce these variables seems to be to have a null-safe version of the class fields, but I'm not sure if this would be better in this case, since one should always use the non-null local variables in these methods anyway, not the shadowed class fields which may be null.