### PR TITLE
Update google-java-format to version 1.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <jgit.version>5.13.0.202109080827-r</jgit.version>
     <jacoco.version>0.8.7</jacoco.version>
     <takari-plugin-testing.version>2.9.2</takari-plugin-testing.version>
-    <google-java-format.version>1.15.0</google-java-format.version>
+    <google-java-format.version>1.16.0</google-java-format.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
See also:
[Release v1.16.0 · google/google-java-format](https://github.com/google/google-java-format/releases/tag/v1.16.0)

See also:
[Update google-java-format to version 1.16.0 · Issue #98 · Cosium/git-code-format-maven-plugin](https://github.com/Cosium/git-code-format-maven-plugin/issues/98)