### PR TITLE
Add preliminary Maven goals to invoke from the pre-commit script

### DIFF
--- a/core/src/main/java/com/cosium/code/format/InstallHooksMojo.java
+++ b/core/src/main/java/com/cosium/code/format/InstallHooksMojo.java
@@ -65,6 +65,13 @@ public class InstallHooksMojo extends AbstractMavenGitCodeFormatMojo {
   @Parameter(property = "gcf.propertiesToAdd")
   private String[] propertiesToAdd;
 
+  /**
+   * The list of preliminary Maven goals to invoke before invoking the main
+   * git-code-format:on-pre-commit goal from the pre-commit script.
+   */
+  @Parameter(property = "gcf.preliminaryGoals")
+  private String[] preliminaryGoals;
+
   @Parameter(property = "gcf.debug", defaultValue = "false")
   private boolean debug;
 
@@ -124,6 +131,7 @@ public class InstallHooksMojo extends AbstractMavenGitCodeFormatMojo {
             StandardCharsets.UTF_8.toString(),
             mavenEnvironment.getMavenExecutable(debug).toAbsolutePath(),
             pomFile().toAbsolutePath(),
+            preliminaryMavenGoalsToInvoke(),
             mavenCliArguments());
     getLog().debug("Written plugin pre commit hook file");
   }
@@ -139,6 +147,10 @@ public class InstallHooksMojo extends AbstractMavenGitCodeFormatMojo {
       legacyPreCommitHookBaseScriptCalls().forEach(basePreCommitHook::removeCommandCall);
     }
     basePreCommitHook.appendCommandCall(preCommitHookBaseScriptCall());
+  }
+
+  private String preliminaryMavenGoalsToInvoke() {
+    return Stream.of(preliminaryGoals).collect(Collectors.joining(" "));
   }
 
   private String mavenCliArguments() {

--- a/core/src/main/resources/com/cosium/code/format/git-code-format.pre-commit.sh
+++ b/core/src/main/resources/com/cosium/code/format/git-code-format.pre-commit.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-%s -f %s com.cosium.code:git-code-format-maven-plugin:on-pre-commit %s
+%s -f %s %s com.cosium.code:git-code-format-maven-plugin:on-pre-commit %s


### PR DESCRIPTION
Make it possible to configure preliminary Maven goals that should be invoked before invoking the main git-code-format:on-pre-commit goal from the pre-commit script.

See also: [Cannot use multiple sourceDirectories · Issue #52 · Cosium/git-code-format-maven-plugin](https://github.com/Cosium/git-code-format-maven-plugin/issues/52#issuecomment-4732467310)